### PR TITLE
Added a method to detect WireShark

### DIFF
--- a/Methods/MethodWireShark.h
+++ b/Methods/MethodWireShark.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <windows.h>
+#include <iostream>
+#include <winsvc.h>
+#include <string>
+
+class DriverDetector {
+private:
+
+    SC_HANDLE scManager;
+
+public:
+
+    DriverDetector() {
+        scManager = OpenSCManager(
+            nullptr,
+            nullptr,
+            SC_MANAGER_ENUMERATE_SERVICE
+        );
+    }
+
+    ~DriverDetector() {
+        if (scManager) {
+            CloseServiceHandle(scManager);
+        }
+    }
+
+    bool isDriverRunning(const std::string& driverName) const {
+        SC_HANDLE serviceHandle = OpenServiceA(
+            scManager,
+            driverName.c_str(),
+            SERVICE_QUERY_STATUS
+        );
+
+        if (serviceHandle == nullptr) {
+            return false;
+        }
+
+        SERVICE_STATUS_PROCESS statusBuffer;
+        DWORD bytesNeeded;
+        bool isRunning = false;
+
+        if (QueryServiceStatusEx(
+            serviceHandle,
+            SC_STATUS_PROCESS_INFO,
+            reinterpret_cast<LPBYTE>(&statusBuffer),
+            sizeof(SERVICE_STATUS_PROCESS),
+            &bytesNeeded)) {
+
+            isRunning = (statusBuffer.dwCurrentState == SERVICE_RUNNING);
+        }
+
+        CloseServiceHandle(serviceHandle);
+        return isRunning;
+    }
+
+    bool stopDriver(const std::string& driverName) const {
+        SC_HANDLE serviceHandle = OpenServiceA(
+            scManager,
+            driverName.c_str(),
+            SERVICE_STOP
+        );
+
+        if (serviceHandle == nullptr) {
+            return false;
+        }
+
+        SERVICE_STATUS status;
+        bool success = ControlService(
+            serviceHandle,
+            SERVICE_CONTROL_STOP,
+            &status
+        );
+
+        CloseServiceHandle(serviceHandle);
+        return success;
+    }
+};
+
+// Usage example
+bool MethodWireShark() {
+    DriverDetector detector;
+
+    // Check for specific driver (In our case WireShark)
+    std::string targetDriver = "npcap";
+
+    if (detector.isDriverRunning(targetDriver)) {
+        std::cout << "The target driver was found!" << std::endl;
+
+        // Stop the driver * REQUIRES ADMINISTRATOR PRIVILEGES *
+        /*
+        if (detector.stopDriver(targetDriver)) {
+            std::cout << "Stopped driver: " << targetDriver << std::endl;
+        }
+        else
+        {
+            std::cerr << "Failed to stop driver: " << targetDriver << std::endl;
+        }
+        */
+
+        return true;
+    }
+    else
+    {
+        std::cout << "The target driver was not found." << std::endl;
+        return false;
+    }
+}

--- a/anti-debugging.cpp
+++ b/anti-debugging.cpp
@@ -21,6 +21,7 @@
 #include "Methods/MethodQPC.h"
 #include "Methods/MethodHeapFlag.h"
 #include "Methods/MethodLFH.h"
+#include "Methods/MethodWireShark.h"
 LRESULT CALLBACK WindowProcedure( HWND, UINT, WPARAM, LPARAM );
 
 void AddMenus( HWND hWnd );
@@ -168,6 +169,7 @@ void AddControls( HWND hWnd ) {
 	AddMethod( MethodGetLocalTime, "GetLocalTime Detection");
 	AddMethod( MethodGetTickCount, "GetTickCount Detection");
 	AddMethod(MethodQPC, "QueryPerformanceCounter Detection");
+    AddMethod(MethodWireShark, "WireShark Detection");
 
 	hLogo = CreateWindowA( "static", NULL, WS_VISIBLE | WS_CHILD | SS_BITMAP, -10, 0, 100, 100, hWnd, NULL, NULL, NULL );
 	SendMessageA( hLogo, STM_SETIMAGE, IMAGE_BITMAP, ( LPARAM )hLogoImage );


### PR DESCRIPTION
Hey there,
Not sure if this is within the scope of this project.

Nevertheless the method I made detects whether the underlying driver, which WireShark uses, is running.
I've also taken the liberty to add a method to stop said driver.

Additional information:
When installed, Npcap runs it's driver (`npcap`) automatically on startup, regardless of WireShark running or not.
When WireShark runs, it locks the driver therefore attempting to stop the driver directly while WireShark **is** running will not work. The application must be closed beforehand.

Important considerations:
This method isn't a replacement from proper server-sided api security and rate limiting.
That being said, this method *could* be used to stop the lowest common denominators from sniffing your api calls.

Improvements:
I could add a method to retrieve the application(s) which are using the npcap driver, to then shut them down one-by-one and finally stop the driver.

I guess I'll wait and see to figure out whether this is in or out of scope.